### PR TITLE
Fix site name and repo URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: ReCoDE Exemplar Template
-repo_url: https://github.com/ImperialCollegeLondon/ReCoDE-exemplar-template
+site_name: ReCoDE Turing Patterns & Partial Differential Equations
+repo_url: https://github.com/ImperialCollegeLondon/ReCoDE-Turing-Patterns-and-Partial-Differential-Equations
 
 ## Please change the above name and link to point to your exemplar
 ## Please do not change the theme or most other options below 


### PR DESCRIPTION
Adjust the site name and repository URL params in the `mkdocs.yml` file, so that the header title and GitHub icon work as expected.